### PR TITLE
Dcos network overlay with docker support

### DIFF
--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/MesosConstants.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/MesosConstants.java
@@ -22,6 +22,7 @@ public class MesosConstants {
     public static final String MARATHON_USERNAME = "MARATHON_USERNAME";
     public static final String MARATHON_PASSWORD = "MARATHON_PASSWORD";
     public static final String ENABLE_BASIC_AUTH = "ENABLE_MARATHON_BASIC_AUTH";
+    public static final String IS_OVERLAY_NETWORK_AND_DOCKER = "IS_OVERLAY_NETWORK_AND_DOCKER";
     public static final String MARATHON_APP_ID = "MARATHON_APP_ID";
     public static final String MESOS_DNS_ENDPOINT = "MESOS_DNS_ENDPOINT";
     public static final String MESOS_MEMBER_DISCOVERY_SCHEME = "MESOS_MEMBER_DISCOVERY_SCHEME";
@@ -30,6 +31,7 @@ public class MesosConstants {
     public static final String DEFAULT_MARATHON_ENDPOINT = "http://marathon.mesos:8080";
     public static final String DEFAULT_MESOS_DNS_ENDPOINT = "http://marathon.mesos:8123";
     public static final String DNS_UPDATE_TIMEOUT = "DNS_UPDATE_TIMEOUT";
+    public static final String IP_ADDRESS_PROTOCOL_IPV4 = "IPv4";
     public static final String DEFAULT_DNS_UPDATE_TIMEOUT = "10"; // in seconds
     public static final int DNS_RETRY_INTERVAL = 5; // in seconds
 }

--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/MesosMembershipScheme.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/MesosMembershipScheme.java
@@ -231,7 +231,7 @@ public class MesosMembershipScheme implements HazelcastMembershipScheme {
             Collection<Task> tasksCollection;
             try {
                 if (isOverlayNetwork) {
-                    addMembersFromMarathonInfo(marathonAppId, marathonClient.getApp(marathonAppId).getApp());
+                    addMembersFromMarathonDockerInfo(marathonAppId, marathonClient.getApp(marathonAppId).getApp());
                 } else {
                     tasksCollection = marathonClient.getApp(marathonAppId).getApp().getTasks();
                     addMembersFromMarathonTasks(marathonAppId, tasksCollection);
@@ -256,7 +256,7 @@ public class MesosMembershipScheme implements HazelcastMembershipScheme {
         }
     }
 
-    private void addMembersFromMarathonInfo(String marathonAppId, App marathonApp) {
+    private void addMembersFromMarathonDockerInfo(String marathonAppId, App marathonApp) {
         if (marathonApp.getContainer() == null || marathonApp.getContainer().getDocker() == null
                 || marathonApp.getContainer().getDocker().getPortMappings() == null
                 || marathonApp.getContainer().getDocker().getPortMappings().isEmpty()) {

--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/IpAddress.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/IpAddress.java
@@ -1,0 +1,25 @@
+package org.wso2.carbon.clustering.mesos.client.model.marathon.v2;
+
+public class IpAddress {
+
+    private String ipAddress;
+
+    private String protocol;
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+}

--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/Task.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/Task.java
@@ -27,6 +27,7 @@ public class Task {
     private String stagedAt;
     private String startedAt;
     private Collection<HealthCheckResult> healthCheckResults;
+    private Collection<IpAddress> ipAddresses;
 
     public String getHost() {
         return host;
@@ -82,6 +83,14 @@ public class Task {
 
     public void setHealthCheckResults(Collection<HealthCheckResult> healthCheckResults) {
         this.healthCheckResults = healthCheckResults;
+    }
+
+    public Collection<IpAddress> getIpAddresses() {
+        return ipAddresses;
+    }
+
+    public void setIpAddresses(Collection<IpAddress> ipAddresses) {
+        this.ipAddresses = ipAddresses;
     }
 
     @Override

--- a/common/mesos-membership-scheme/src/test/java/org/wso2/carbon/clustering/mesos/test/live/MesosMembershipSchemeTestCase.java
+++ b/common/mesos-membership-scheme/src/test/java/org/wso2/carbon/clustering/mesos/test/live/MesosMembershipSchemeTestCase.java
@@ -36,26 +36,47 @@ public class MesosMembershipSchemeTestCase {
     private static final Log log = LogFactory.getLog(MesosMembershipSchemeTestCase.class);
 
     @Test
-    public void testMarathonClient() throws Exception {
+    public void testMarathonClientWithOverlay() throws Exception {
         Config primaryHazelcastConfig;
         HazelcastInstance primaryHazelcastInstance;
         Map<String, Parameter> parameters = new HashMap<>();
         List<ClusteringMessage> messageBuffer;
 
-        parameters.put(MesosConstants.MARATHON_ENDPOINT, new Parameter(MesosConstants.MARATHON_ENDPOINT,
-                "http://m1.dcos:8080"));
-        parameters.put(MesosConstants.MARATHON_APP_ID, new Parameter(MesosConstants.MARATHON_ENDPOINT,
-                "wso2esb-worker"));
-        parameters.put(MesosConstants.MARATHON_APPLICATIONS, new Parameter(MesosConstants.MARATHON_ENDPOINT,
-                "wso2esb-manager"));
+        parameters.put(MesosConstants.MARATHON_ENDPOINT, new Parameter(MesosConstants.MARATHON_ENDPOINT, "http://m1.dcos:8080"));
+        parameters.put(MesosConstants.MARATHON_APP_ID, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-worker"));
+        parameters.put(MesosConstants.MARATHON_APPLICATIONS, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-manager"));
+        parameters.put(MesosConstants.IS_OVERLAY_NETWORK_AND_DOCKER, new Parameter(MesosConstants.IS_OVERLAY_NETWORK_AND_DOCKER, "true"));
 
         String primaryDomain = "TestDomain";
         messageBuffer = new ArrayList<>();
         primaryHazelcastConfig = new Config();
         primaryHazelcastInstance = Hazelcast.newHazelcastInstance(primaryHazelcastConfig);
 
-        MesosMembershipScheme mesosMembershipScheme = new MesosMembershipScheme(parameters, primaryDomain,
-                primaryHazelcastConfig, primaryHazelcastInstance, messageBuffer);
+        MesosMembershipScheme mesosMembershipScheme = new MesosMembershipScheme(parameters, primaryDomain, primaryHazelcastConfig,
+                primaryHazelcastInstance, messageBuffer);
+        mesosMembershipScheme.init();
+        TcpIpConfig tcpIpConfig = primaryHazelcastConfig.getNetworkConfig().getJoin().getTcpIpConfig();
+        log.info("Hazelcast cluster member list: " + tcpIpConfig.getMembers());
+    }
+
+    @Test
+    public void testMarathonClient() throws Exception {
+        Config primaryHazelcastConfig;
+        HazelcastInstance primaryHazelcastInstance;
+        Map<String, Parameter> parameters = new HashMap<>();
+        List<ClusteringMessage> messageBuffer;
+
+        parameters.put(MesosConstants.MARATHON_ENDPOINT, new Parameter(MesosConstants.MARATHON_ENDPOINT, "http://m1.dcos:8080"));
+        parameters.put(MesosConstants.MARATHON_APP_ID, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-worker"));
+        parameters.put(MesosConstants.MARATHON_APPLICATIONS, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-manager"));
+
+        String primaryDomain = "TestDomain";
+        messageBuffer = new ArrayList<>();
+        primaryHazelcastConfig = new Config();
+        primaryHazelcastInstance = Hazelcast.newHazelcastInstance(primaryHazelcastConfig);
+
+        MesosMembershipScheme mesosMembershipScheme = new MesosMembershipScheme(parameters, primaryDomain, primaryHazelcastConfig,
+                primaryHazelcastInstance, messageBuffer);
         mesosMembershipScheme.init();
         TcpIpConfig tcpIpConfig = primaryHazelcastConfig.getNetworkConfig().getJoin().getTcpIpConfig();
         log.info("Hazelcast cluster member list: " + tcpIpConfig.getMembers());
@@ -68,23 +89,19 @@ public class MesosMembershipSchemeTestCase {
         Map<String, Parameter> parameters = new HashMap<>();
         List<ClusteringMessage> messageBuffer;
 
-        parameters.put(MesosConstants.MESOS_DNS_ENDPOINT, new Parameter(MesosConstants.MESOS_DNS_ENDPOINT,
-                "http://m1.dcos:8123"));
-        parameters.put(MesosConstants.MESOS_MEMBER_DISCOVERY_SCHEME, new Parameter(MesosConstants
-                .MESOS_MEMBER_DISCOVERY_SCHEME,
-                MesosConstants.MESOS_DNS_DISCOVERY_SCHEME));
-        parameters.put(MesosConstants.MARATHON_APP_ID, new Parameter(MesosConstants.MARATHON_ENDPOINT,
-                "wso2esb-worker"));
-        parameters.put(MesosConstants.MARATHON_APPLICATIONS, new Parameter(MesosConstants.MARATHON_ENDPOINT,
-                "wso2esb-manager"));
+        parameters.put(MesosConstants.MESOS_DNS_ENDPOINT, new Parameter(MesosConstants.MESOS_DNS_ENDPOINT, "http://m1.dcos:8123"));
+        parameters.put(MesosConstants.MESOS_MEMBER_DISCOVERY_SCHEME,
+                new Parameter(MesosConstants.MESOS_MEMBER_DISCOVERY_SCHEME, MesosConstants.MESOS_DNS_DISCOVERY_SCHEME));
+        parameters.put(MesosConstants.MARATHON_APP_ID, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-worker"));
+        parameters.put(MesosConstants.MARATHON_APPLICATIONS, new Parameter(MesosConstants.MARATHON_ENDPOINT, "wso2esb-manager"));
 
         String primaryDomain = "TestDomain";
         messageBuffer = new ArrayList<>();
         primaryHazelcastConfig = new Config();
         primaryHazelcastInstance = Hazelcast.newHazelcastInstance(primaryHazelcastConfig);
 
-        MesosMembershipScheme mesosMembershipScheme = new MesosMembershipScheme(parameters, primaryDomain,
-                primaryHazelcastConfig, primaryHazelcastInstance, messageBuffer);
+        MesosMembershipScheme mesosMembershipScheme = new MesosMembershipScheme(parameters, primaryDomain, primaryHazelcastConfig,
+                primaryHazelcastInstance, messageBuffer);
         mesosMembershipScheme.init();
         TcpIpConfig tcpIpConfig = primaryHazelcastConfig.getNetworkConfig().getJoin().getTcpIpConfig();
         log.info("Hazelcast cluster member list: " + tcpIpConfig.getMembers());


### PR DESCRIPTION
Hello,

I leave another PR to merge the change we have done to support the clustering in a DC/OS 1.8 with overlay networks ( and docker instances. The issue here was that if we tried the MesosDNS strategy, with the current logic, we were getting the mapped port, and not the containerPort, that would be the ones the other containers would be able to use for communication between each other, being in the same overlay. And for Marathon, it gets the host IP address, that is not the internal overlay network IP assigned, so it wouldn't work either.

So we wrote new logic, activated by a boolean flag (we can rename it or use another strategy to detect what to do, this is just an option) to get the information from Marathon this way:

- For the port, it gets the lowest port of the containerPorts listed.
- For the ipAddress, it gets the first IPv4 Ipaddress listed in the IPAddresses list.

Every comment is more than welcome.

Thank you!

Jose Maria.