### PR TITLE
Adapt marathon model for health check commands

### DIFF
--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/Command.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/Command.java
@@ -1,0 +1,15 @@
+package org.wso2.carbon.clustering.mesos.client.model.marathon.v2;
+
+public class Command {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/HealthCheck.java
+++ b/common/mesos-membership-scheme/src/main/java/org/wso2/carbon/clustering/mesos/client/model/marathon/v2/HealthCheck.java
@@ -18,7 +18,7 @@ package org.wso2.carbon.clustering.mesos.client.model.marathon.v2;
 import org.wso2.carbon.clustering.mesos.client.utils.ModelUtils;
 
 public class HealthCheck {
-    private String command;
+    private Command command;
     private Integer gracePeriodSeconds;
     private Integer intervalSeconds;
     private Integer maxConsecutiveFailures;
@@ -92,11 +92,11 @@ public class HealthCheck {
         this.protocol = protocol;
     }
 
-    public String getCommand() {
+    public Command getCommand() {
         return command;
     }
 
-    public void setCommand(String command) {
+    public void setCommand(Command command) {
         this.command = command;
     }
 


### PR DESCRIPTION
Hi,

I've modified the model for the Marathon API in DC/OS 1.8 so that it reflects the changes they have done to the health check information. It impacted our deployment when we changed the health check to command in DC/OS.

Hope it helps,

Jose Maria.